### PR TITLE
Fix crouton check

### DIFF
--- a/mush.sh
+++ b/mush.sh
@@ -83,7 +83,7 @@ main() {
 (8) Emergency Revert & Re-Enroll
 (9) Edit Pollen
 EOF
-        if ! test -f /mnt/stateful_partition/crouton; then
+        if ! test -d /mnt/stateful_partition/crouton; then
             echo "(10) Install Crouton"
         else
             echo "(11) Start Crouton"


### PR DESCRIPTION
At least on my chromebook: ```
localhost ~ # ls -ld /mnt/stateful_partition/crouton
drwxr-xr-x. 3 root root 4096 Mar 17 14:58 /mnt/stateful_partition/crouton
```
Can check for both with an `||` if you think that's needed. 

Any reason `test` is used rather than the bash-specific `[[ ]]`?