### PR TITLE
bug fix in extension hard-disabling/enabling in mush

### DIFF
--- a/mush.sh
+++ b/mush.sh
@@ -272,8 +272,7 @@ harddisableext() { # calling it "hard disable" because it only reenables when yo
     13) read -r -p "enter extension id>" extid;;
     *) echo "invalid option" ;;
     esac
-    chmod 000 "/home/chronos/user/Extensions/$extid"
-    kill -9 $(pgrep -f "\-\-extension\-process")
+    echo "$extid" | grep -qE '^[a-z]{32}$' && chmod 000 "/home/chronos/user/Extensions/$extid" && kill -9 $(pgrep -f "\-\-extension\-process") || "invalid input"
 }
 
 hardenableext() {
@@ -308,8 +307,7 @@ hardenableext() {
     13) read -r -p "enter extension id>" extid;;
     *) echo "invalid option" ;;
     esac
-    chmod 777 "/home/chronos/user/Extensions/$extid"
-    kill -9 $(pgrep -f "\-\-extension\-process")
+    echo "$extid" | grep -qE '^[a-z]{32}$' && chmod 777 "/home/chronos/user/Extensions/$extid" && kill -9 $(pgrep -f "\-\-extension\-process") || "invalid input"
 }
 
 softdisableext() {


### PR DESCRIPTION
fixes two things:
1. verifies the variable `extid` is actually an extension ID
2. makes sure typing an invalid input doesnt remove your perms for your user's entire extension folder (since there was no check on the `extid` variable, it would run `chmod 000` on "/home/chronos/user/Extensions/$extid" even if $extid is unset, meaning the chmod command was run on the "/home/chronos/user/Extensions/" directory as a whole)