### PR TITLE
Replace get_largest_nvme_namespace implementation

### DIFF
--- a/fakemurk.sh.pre
+++ b/fakemurk.sh.pre
@@ -57,7 +57,7 @@ EOF
 get_largest_cros_blockdev() {
     local largest size dev_name tmp_size remo
     size=0
-    for blockdev in /sys/block/*; do
+    for blockdev in /sys/block/"${dev%n*}"*; do
         dev_name="${blockdev##*/}"
         echo "$dev_name" | grep -q '^\(loop\|ram\)' && continue
         tmp_size=$(cat "$blockdev"/size)

--- a/fakemurk.sh.pre
+++ b/fakemurk.sh.pre
@@ -54,20 +54,24 @@ EOF
     fi
 }
 
-get_largest_nvme_namespace() {
-    # this function doesn't exist if the version is old enough, so we redefine it
-    local largest size tmp_size dev
+get_largest_cros_blockdev() {
+    local largest size dev_name tmp_size remo
     size=0
-    dev=$(basename "$1")
-
-    for nvme in /sys/block/"${dev%n*}"*; do
-        tmp_size=$(cat "${nvme}"/size)
-        if [ "${tmp_size}" -gt "${size}" ]; then
-            largest="${nvme##*/}"
-            size="${tmp_size}"
+    for blockdev in /sys/block/*; do
+        dev_name="${blockdev##*/}"
+        echo "$dev_name" | grep -q '^\(loop\|ram\)' && continue
+        tmp_size=$(cat "$blockdev"/size)
+        remo=$(cat "$blockdev"/removable)
+        if [ "$tmp_size" -gt "$size" ] && [ "${remo:-0}" -eq 0 ]; then
+            case "$(sfdisk -l -o name "/dev/$dev_name" 2>/dev/null)" in
+                *STATE*KERN-A*ROOT-A*KERN-B*ROOT-B*)
+                    largest="/dev/$dev_name"
+                    size="$tmp_size"
+                    ;;
+            esac
         fi
     done
-    echo "${largest}"
+    echo "$largest"
 }
 verity_enabled_for_n() {
     grep -q "root=/dev/dm" <"${DST}p${1}"
@@ -103,9 +107,10 @@ configure_target() {
     # remember, the goal here is to end up with one kernel that can be patched, and one kernel for the revert function.
     # we prioritize the non booted kernel so a reboot isn't needed
 
-    DST=/dev/$(get_largest_nvme_namespace)
-    if [ "$DST" == "/dev/" ]; then
-        DST=/dev/mmcblk0
+    DST="$(get_largest_cros_blockdev)"
+    if [ "$DST" == "" ]; then
+        echo "No CrOS SSD found on device!"
+        leave
     fi
 
     if verity_enabled_for_n 2 && verity_enabled_for_n 4; then


### PR DESCRIPTION
This uses an implementation of `get_largest_nvme_namespace` [from cryptosmite](https://github.com/FWSmasher/CryptoSmite/blob/39a235386957207185af844b0521e8a2d90c4440/cryptosmite.sh#L30) which works much better than the original.

Before, USBs larger than the rootfs would get detected as the rootfs device.

closes #51 
also closes #52 